### PR TITLE
test:[AIC-18] Update profile tests to use a consistent user ID

### DIFF
--- a/src/tests/profile.controller.int.test.ts
+++ b/src/tests/profile.controller.int.test.ts
@@ -4,7 +4,7 @@ import app from "../index";
 describe("Profile API Integration - GET", () => {
   describe("GET /profiles/:id", () => {
     it("should return 200 and a profile if ID exists", async () => {
-      const res = await request(app).get("/profiles/1");
+      const res = await request(app).get("/profiles/999");
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("id");
       expect(res.body).toHaveProperty("firstName");
@@ -28,7 +28,7 @@ describe("Profile API Integration - PUT", () => {
   describe("PUT /profiles/:id", () => {
     it("should return 200 and update the profile", async () => {
       const res = await request(app)
-        .put("/profiles/1")
+        .put("/profiles/999")
         .send({
           firstName: "Jean",
           lastName: "Testé",
@@ -47,7 +47,7 @@ describe("Profile API Integration - PUT", () => {
 
     it("should return 400 for missing fields", async () => {
       const res = await request(app)
-        .put("/profiles/1")
+        .put("/profiles/999")
         .send({
           firstName: "",
           lastName: "",
@@ -83,7 +83,7 @@ describe("Profile API Integration - PUT", () => {
 describe("Profile API Integration - DELETE", () => {
   describe("DELETE /profiles/:id", () => {
     it("should return 200 if profile is deleted successfully", async () => {
-      const res = await request(app).delete("/profiles/1");
+      const res = await request(app).delete("/profiles/999");
       expect([200, 404]).toContain(res.status);
     });
 

--- a/src/tests/profile.service.test.ts
+++ b/src/tests/profile.service.test.ts
@@ -12,7 +12,7 @@ const prisma = new PrismaClient();
 beforeAll(async () => {
   await prisma.user.create({
     data: {
-      USEN_ID: 1,
+      USEN_ID: 999,
       USEC_FNAME: "Maxime",
       USEC_LNAME: "Test",
       USED_BIRTH: new Date("1990-01-01"),
@@ -25,7 +25,6 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await prisma.user.deleteMany();
   await prisma.$disconnect();
 });
 

--- a/src/tests/profile.userProfile.test.ts
+++ b/src/tests/profile.userProfile.test.ts
@@ -3,7 +3,7 @@ import UserProfile from "../models/userProfile";
 describe("userProfile model", () => {
   it("should instantiate and return values via getters", () => {
     const profile = new UserProfile(
-      1,
+      999,
       "Doe",
       "John",
       new Date("1990-01-01"),
@@ -13,7 +13,7 @@ describe("userProfile model", () => {
       "Bio text",
     );
 
-    expect(profile.getId()).toBe(1);
+    expect(profile.getId()).toBe(999);
     expect(profile.getLastName()).toBe("Doe");
     expect(profile.getFirstName()).toBe("John");
     expect(profile.getBirthDate()).toEqual(new Date("1990-01-01"));
@@ -24,7 +24,7 @@ describe("userProfile model", () => {
   });
 
   it("should update fields using setters", () => {
-    const profile = new UserProfile(1)
+    const profile = new UserProfile(999)
       .setFirstName("Jane")
       .setLastName("Smith")
       .setBirthDate(new Date("2000-01-01"))


### PR DESCRIPTION
This pull request updates test cases across multiple files to use a consistent test user ID (`999`) instead of `1`. Additionally, it removes redundant cleanup code in the `profile.service.test.ts` file. These changes improve test consistency and simplify test maintenance.

### Test ID Consistency Updates:
* [`src/tests/profile.controller.int.test.ts`](diffhunk://#diff-09d0c480cc31479499a46babc8a59629a36d6f884ccaf4a8d3e1dd923acf9925L7-R7): Updated all test cases to use the ID `999` instead of `1` for API endpoints like `GET`, `PUT`, and `DELETE`. [[1]](diffhunk://#diff-09d0c480cc31479499a46babc8a59629a36d6f884ccaf4a8d3e1dd923acf9925L7-R7) [[2]](diffhunk://#diff-09d0c480cc31479499a46babc8a59629a36d6f884ccaf4a8d3e1dd923acf9925L31-R31) [[3]](diffhunk://#diff-09d0c480cc31479499a46babc8a59629a36d6f884ccaf4a8d3e1dd923acf9925L50-R50) [[4]](diffhunk://#diff-09d0c480cc31479499a46babc8a59629a36d6f884ccaf4a8d3e1dd923acf9925L86-R86)
* [`src/tests/profile.service.test.ts`](diffhunk://#diff-81897cd1d02c597b7895c9bf1cd45f3f05a0a64182c3fae908216d9e1370a4acL15-R15): Changed the `USEN_ID` in the test setup to `999` for consistency.
* [`src/tests/profile.userProfile.test.ts`](diffhunk://#diff-3ba387e9c5060fcf4ca65b98f980b729ab89c2f5e606744871152161627e27e6L6-R6): Updated the `UserProfile` model tests to use `999` instead of `1` for instantiation and assertions. [[1]](diffhunk://#diff-3ba387e9c5060fcf4ca65b98f980b729ab89c2f5e606744871152161627e27e6L6-R6) [[2]](diffhunk://#diff-3ba387e9c5060fcf4ca65b98f980b729ab89c2f5e606744871152161627e27e6L16-R16) [[3]](diffhunk://#diff-3ba387e9c5060fcf4ca65b98f980b729ab89c2f5e606744871152161627e27e6L27-R27)

### Cleanup Simplification:
* [`src/tests/profile.service.test.ts`](diffhunk://#diff-81897cd1d02c597b7895c9bf1cd45f3f05a0a64182c3fae908216d9e1370a4acL28): Removed the `prisma.user.deleteMany()` call in the `afterAll` block, as it was deemed unnecessary.